### PR TITLE
Improved map for pydata london news

### DIFF
--- a/2026-02-03_PyData-News-February-2026/2026-02-03_PyData-News-February-2026.ipynb
+++ b/2026-02-03_PyData-News-February-2026/2026-02-03_PyData-News-February-2026.ipynb
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 23,
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -210,7 +210,7 @@
        "        <iframe\n",
        "            width=\"1024\"\n",
        "            height=\"600\"\n",
-       "            src=\"https://hevansdev.github.io/mapping-pydata/pydata_world_map.html#3/26.2737/13.0078\"\n",
+       "            src=\"https://hevansdev.github.io/mapping-pydata/pydata_world_map.html#1/-35.4607/-33.7500\"\n",
        "            frameborder=\"0\"\n",
        "            allowfullscreen\n",
        "            \n",
@@ -218,16 +218,16 @@
        "        "
       ],
       "text/plain": [
-       "<IPython.lib.display.IFrame at 0x10a1a0510>"
+       "<IPython.lib.display.IFrame at 0x10a19c210>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "IFrame('https://hevansdev.github.io/mapping-pydata/pydata_world_map.html#3/26.2737/13.0078', **default_size)"
+    "IFrame('https://hevansdev.github.io/mapping-pydata/pydata_world_map.html#1/-35.4607/-33.7500', **default_size)"
    ]
   },
   {


### PR DESCRIPTION
Replace existing screenshots of Meetup Pro map of international and UK based PyData meetups with Iframe which update daily based on scraped data from meetup.com.

This fixes issues with groups being shown in the wrong locations on the Meetup map and all groups being shown at an offset.

Before

<img width="639" height="843" alt="Screenshot 2026-02-05 at 20 56 42" src="https://github.com/user-attachments/assets/6c0d727f-5c5f-4db4-a30e-ce73301a6d43" />


After

<img width="741" height="961" alt="Screenshot 2026-02-05 at 20 58 17" src="https://github.com/user-attachments/assets/b4e0d573-9faf-47d4-8fb5-84bd79ce5046" />
